### PR TITLE
Fixed varipus incompatibilities so it would compile for Termux

### DIFF
--- a/dev/externals/mctools/chxformat.c
+++ b/dev/externals/mctools/chxformat.c
@@ -41,7 +41,7 @@ char* guidnames[] = {"PCM","PCM FLOAT","AMB PCM","AMB FLOAT"};
 #define REVWBYTES(t)    ( (((t)&0xff) << 8) | (((t)>>8) &0xff) )
 #define TAG(a,b,c,d)    ( ((a)<<24) | ((b)<<16) | ((c)<<8) | (d) )
 
-#ifdef linux
+#ifdef __GLIBC__
 #define POS64(x) (x.__pos)
 #else
 #define POS64(x) (x)

--- a/dev/externals/portsf/portsf.c
+++ b/dev/externals/portsf/portsf.c
@@ -90,7 +90,7 @@ int stricmp(const char *a, const char *b);
 int strnicmp(const char *a, const char *b, const int length);
 #endif
 
-#ifdef linux
+#ifdef __GLIBC__
 #define POS64(x) (x.__pos)
 #else
 #define POS64(x) (x)

--- a/dev/newsfsys/pvfileio.c
+++ b/dev/newsfsys/pvfileio.c
@@ -41,8 +41,8 @@
 #ifdef unix
 #include <unistd.h>
 #define O_BINARY (0)
-#define _S_IWRITE S_IWRITE
-#define _S_IREAD  S_IREAD
+#define _S_IWRITE S_IWUSR
+#define _S_IREAD  S_IRUSR
 #endif
 
 #ifdef _DEBUG

--- a/dev/newsfsys/sfsys.c
+++ b/dev/newsfsys/sfsys.c
@@ -188,8 +188,8 @@ int CDP_COM_READY = 0;   /*global flag, ah well...(define in alias.h will access
 #define _O_CREAT        O_CREAT
 #define _O_TRUNC        O_TRUNC
 #define _O_EXCL         O_EXCL
-#define _S_IWRITE       S_IWRITE
-#define _S_IREAD        S_IREAD
+#define _S_IWRITE       S_IWUSR
+#define _S_IREAD        S_IRUSR
 
 #define chsize  ftruncate
 #endif

--- a/dev/newsfsys/sfsys.c
+++ b/dev/newsfsys/sfsys.c
@@ -280,7 +280,7 @@ extern int sampsize[];
 #define sizeof_WFMTEX (40)
 
 
-#ifdef linux
+#ifdef __GLIBC__
 #define POS64(x) (x.__pos)
 #else
 #define POS64(x) (x)

--- a/dev/pvxio2/pvfileio.c
+++ b/dev/pvxio2/pvfileio.c
@@ -41,8 +41,8 @@
 #ifdef unix
 #include <unistd.h>
 #define O_BINARY (0)
-#define _S_IWRITE S_IWRITE
-#define _S_IREAD  S_IREAD
+#define _S_IWRITE S_IWUSR
+#define _S_IREAD  S_IRUSR
 #endif
 
 #ifdef _DEBUG

--- a/dev/sfsys/sfsys.c
+++ b/dev/sfsys/sfsys.c
@@ -274,7 +274,7 @@ extern int sampsize[];
 #define sizeof_WFMTEX (40)
 
 
-#ifdef linux
+#ifdef __GLIBC__
 #define POS64(x) (x.__pos)
 #else
 #define POS64(x) (x)

--- a/dev/sfsys/sfsys.c
+++ b/dev/sfsys/sfsys.c
@@ -180,8 +180,8 @@ int CDP_COM_READY = 0;   /*global flag, ah well...(define in alias.h will access
 #define _O_CREAT        O_CREAT
 #define _O_TRUNC        O_TRUNC
 #define _O_EXCL         O_EXCL
-#define _S_IWRITE       S_IWRITE
-#define _S_IREAD        S_IREAD
+#define _S_IWRITE       S_IWUSR
+#define _S_IREAD        S_IRUSR
 
 #define chsize  ftruncate
 #endif

--- a/libaaio/README.md
+++ b/libaaio/README.md
@@ -1,0 +1,11 @@
+# Notes on `./configure`:
+If `./configure` ever fails at checking your compiler, it's probably because your compiler doesn't support implicit `int` declarations. To fix it, run:
+```sh
+sed -i "1083s/^/int /" configure
+```
+.
+P.S.: Also look at updating the `config.guess` and `config.sub` files as those are obsolete and could fail you. Run:
+```sh
+rm config.guess && rm config.sub && wget https://git.savannah.gnu.org/cgit/config.git/plain/config.guess && wget https://git.savannah.gnu.org/cgit/config.git/plain/config.sub
+```
+to fix the issue. 


### PR DESCRIPTION
Trying to find some way of replicating the timer function in `dev/externals/fastconv/fconv.cpp` since `sys/timeb.h` doesn't exist in Android's bionic C library nor in other *NIXes but this is all that made it compile.