### PR TITLE
On Mac, the build fails because of a missing const.

### DIFF
--- a/dev/newsfsys/sfdir.c
+++ b/dev/newsfsys/sfdir.c
@@ -46,7 +46,7 @@
 #include "scandir.h"
 #endif
 
-#if defined WIN32 || defined linux
+#if defined WIN32 || defined linux || defined __APPLE__
 static int
 selfn(const struct dirent *d)
 #else


### PR DESCRIPTION
The error is:
```
/Users/iota/Projects/CDP8/dev/newsfsys/sfdir.c:97:44: error: incompatible function pointer types passing 'int (struct dirent *)' to parameter of type 'int (*)(const struct dirent *)' [-Wincompatible-function-pointer-types]
   97 |     if((numfiles = scandir(".", &filelist, selfn, alphasort)) < 0)
      |                                            ^~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/usr/include/dirent.h:150:11: note: passing argument to parameter here
  150 |     int (*)(const struct dirent *), int (*)(const struct dirent **, const struct dirent **)) __DARWIN_INODE64(scandir);
      |           ^
1 error generated.
```
It happens only on Mac when macros `WIN32` and `linux` are not defined.

I see there is the same code in the file dev/sfsys/sfdir.c but it seems not used, should I update it as well or is it dead code?