### PR TITLE
fix syntax error while building on linux

### DIFF
--- a/dev/new/newtex.c
+++ b/dev/new/newtex.c
@@ -1254,7 +1254,7 @@ int usage2(char *str)
         "\n"
         "Hit key 's' to continue to \"SPACETYPE\" information, or 'e' to exit.\n");
 
-        while((k = _getch())!='s' && k != 'e')
+        while((k = getch())!='s' && k != 'e')
             ;
         if(k == 's') {
             fprintf(stderr,
@@ -3715,3 +3715,4 @@ void bounce_off_src_end_if_necessary(int *here,int thisdur,int sndlen)
         *here = max(0,*here);   //  SAFETY
     }
 }
+


### PR DESCRIPTION
Line 1257, "_getch()" unrecognized, outputs error,

" /home/d44/Documents/CDP8/dev/new/newtex.c: In function ‘usage2’:
/home/d44/Documents/CDP8/dev/new/newtex.c:1257:20: warning: implicit declaration of function ‘_getch’; did you mean ‘getch’? [-Wimplicit-function-declaration]
 1257 |         while((k = _getch())!='s' && k != 'e')
      |                    ^~~~~~
      |                    getch
[ 31%] Linking C executable /home/d44/Documents/CDP8/NewRelease/newtex
/usr/bin/ld: CMakeFiles/newtex.dir/newtex.c.o: in function `usage2':
newtex.c:(.text+0x4b78): undefined reference to `_getch'
collect2: error: ld returned 1 exit status
make[2]: *** [dev/new/CMakeFiles/newtex.dir/build.make:101: /home/d44/Documents/CDP8/NewRelease/newtex] Error 1
make[1]: *** [CMakeFiles/Makefile2:2861: dev/new/CMakeFiles/newtex.dir/all] Error 2
make: *** [Makefile:156: all] Error 2 "

after removing the underscore it successfully builds.